### PR TITLE
Removed a validation that does not allow to sync up with the blockchain

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -1256,8 +1256,7 @@ public abstract class AbstractBlockChain {
         StoredBlock cursor = blockStore.get(prev.getHash());
 
         int blockstogoback = params.getInterval() - 1;
-        if(storedPrev.getHeight()+1 != params.getInterval())
-            blockstogoback = params.getInterval();
+
 
         for (int i = 0; i < blockstogoback; i++) {
             if (cursor == null) {


### PR DESCRIPTION
In the android Wallet when tried to restore with passphrase it didn't sync up correctly with the blockchain. On this PR is now fixed